### PR TITLE
Move read/write json into get/put and update tests

### DIFF
--- a/keys.json
+++ b/keys.json
@@ -1,1 +1,1 @@
-{"TestKey": "OutputTetris.png"}
+{}

--- a/src/app.py
+++ b/src/app.py
@@ -23,20 +23,6 @@ api = Api(
 
 ns = api.namespace("S4", description="S4 API Endpoints")
 
-# def get_keys_to_files():
-#     with open("../keys.json", "r") as f:
-#         keys_to_files = json.load(f)
-
-# def clear_keys_to_files():
-#     keys_to_files = {}
-
-
-# def handleShutdown():
-#     with open("../keys.json", "w") as f:
-#         f.write(json.dumps(keys_to_files))
-# atexit.register(handleShutdown)
-
-
 # --------------------- API Model for example header/body and the response ---------------------
 Key_example = api.model(
     "Key",
@@ -198,7 +184,7 @@ class listObjects(Resource):
     def get(self):
         with open("../keys.json", "r") as f:
             keys_to_files = json.load(f)
-            
+
         file_names = [keys_to_files[key] for key in keys_to_files]
         return {"msg": "Files retrieved successfully", "files": file_names}, 200
 

--- a/src/app.py
+++ b/src/app.py
@@ -23,16 +23,18 @@ api = Api(
 
 ns = api.namespace("S4", description="S4 API Endpoints")
 
-with open("../keys.json", "r") as f:
-    keys_to_files = json.load(f)
+# def get_keys_to_files():
+#     with open("../keys.json", "r") as f:
+#         keys_to_files = json.load(f)
+
+# def clear_keys_to_files():
+#     keys_to_files = {}
 
 
-def handleShutdown():
-    with open("../keys.json", "w") as f:
-        f.write(json.dumps(keys_to_files))
-
-
-atexit.register(handleShutdown)
+# def handleShutdown():
+#     with open("../keys.json", "w") as f:
+#         f.write(json.dumps(keys_to_files))
+# atexit.register(handleShutdown)
 
 
 # --------------------- API Model for example header/body and the response ---------------------
@@ -122,6 +124,10 @@ class getObject(Resource):
     @ns.doc("GetObject")
     @api.response(200, "Success", model=GetObject_example)
     def get(self):
+        # TODO: make into a DAO layer with transactions
+        with open("../keys.json", "r") as f:
+            keys_to_files = json.load(f)
+        
         # get the key from the request parameters
         args = request.args
         Key = args.get("Key")
@@ -149,6 +155,9 @@ class putObject(Resource):
     @api.response(400, "Empty filepath")
     @api.response(404, "No file specified")
     def put(self):
+        with open("../keys.json", "r") as f:
+            keys_to_files = json.load(f)
+        
         # get the key from the request parameters
         args = request.args
         Key = args.get("Key")
@@ -175,6 +184,8 @@ class putObject(Resource):
             else:
                 keys_to_files[Key] = filename
                 file.save(os.path.join(FILE_PATH, Key))
+                with open("../keys.json", "w") as f:
+                    f.write(json.dumps(keys_to_files))
 
         return {"msg": "File successfully saved"}, 201
 
@@ -185,6 +196,9 @@ class listObjects(Resource):
     @ns.doc("ListObjects")
     @api.response(200, "Success", model=ListObjects_example)
     def get(self):
+        with open("../keys.json", "r") as f:
+            keys_to_files = json.load(f)
+            
         file_names = [keys_to_files[key] for key in keys_to_files]
         return {"msg": "Files retrieved successfully", "files": file_names}, 200
 

--- a/src/app.py
+++ b/src/app.py
@@ -195,6 +195,9 @@ class deleteObject(Resource):
     @ns.doc("DeleteObject")
     @api.response(200, "Success", model=DeleteObject_example)
     def put(self):
+        with open("../keys.json", "r") as f:
+            keys_to_files = json.load(f)
+
         # get the key from the request parameters
         args = request.args
         Key = args.get("Key")
@@ -207,6 +210,8 @@ class deleteObject(Resource):
 
         # remove entry from json
         keys_to_files.pop(Key)
+        with open("../keys.json", "w") as f:
+            f.write(json.dumps(keys_to_files))
 
         # remove file from filesystem
         os.remove(os.path.join(FILE_PATH, Key))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,11 +5,14 @@ import pytest, json
 
 @pytest.fixture(autouse=True)
 def do_not_mutate_keys_json():
+    # save keys.json before modification
     with open("../keys.json", "r") as f:
         keys_to_files = json.load(f)
 
+    # test will be run here
     yield 
 
+    # restore keys.json to original state
     with open("../keys.json", "w") as f:
         f.write(json.dumps(keys_to_files))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,15 +1,25 @@
 from io import BytesIO
 from typing import Dict
-import re, os
+import pytest, json
 
 
-def testLanding(app, client):
+@pytest.fixture(autouse=True)
+def do_not_mutate_keys_json():
+    with open("../keys.json", "r") as f:
+        keys_to_files = json.load(f)
+
+    yield 
+
+    with open("../keys.json", "w") as f:
+        f.write(json.dumps(keys_to_files))
+
+def test_landing(app, client):
     del app
     response = client.get("/")
     assert response.status_code == 200
 
 
-def testGenerateKey(client):
+def test_generate_key(client):
     response = client.get("/S4/generateKey")
     assert response.status_code == 200
     assert response
@@ -17,7 +27,7 @@ def testGenerateKey(client):
     # assert len(response.data["Key"]) == 16
 
 
-def testPutObject(client):
+def test_put_object(client):
     f = open("./InputTetris.png", "rb")
     data = dict(file=(BytesIO(f.read()), "OutputTetris.png"))
 
@@ -27,27 +37,39 @@ def testPutObject(client):
     assert response.status_code == 201
 
 
-def testPutDuplicateKey(client):
+def test_put_duplicate_key(client):
     f = open("./InputTetris.png", "rb")
     data = dict(file=(BytesIO(f.read()), "OutputTetris.png"))
 
-    response = client.put(
+    first_response = client.put(
         "/S4/PutObject?Key=TestKey", content_type="multipart/form-data", data=data
     )
-    assert response.status_code == 400
-    assert response.json["msg"] == "Key not unique"
+    assert first_response.status_code == 201
+
+    data = dict(file=(BytesIO(f.read()), "OutputTetris.png"))
+    second_response = client.put(
+        "/S4/PutObject?Key=TestKey", content_type="multipart/form-data", data=data
+    )
+    assert second_response.status_code == 400
+    assert second_response.json["msg"] == "Key not unique"
 
 
-# THIS FUNCTION NEEDS TO BE AFTER THE testPutObject test TO WORK.
-def testGetObject(client):
-    response = client.get(
+def test_get_object(client):
+    f = open("./InputTetris.png", "rb")
+    data = dict(file=(BytesIO(f.read()), "OutputTetris.png"))
+    put_response = client.put(
+        "/S4/PutObject?Key=TestKey", content_type="multipart/form-data", data=data
+    )
+    assert put_response.status_code == 201
+
+    get_response = client.get(
         "/S4/GetObject?Key=TestKey", content_type="multipart/form-data"
     )
-    assert response.status_code == 200
+    assert get_response.status_code == 200
     # TODO test that the object we get back is the same as the object we sent
 
 
-def testListObject(client):
+def test_list_objects(client):
     response = client.get("/S4/ListObjects")
     assert response.status_code == 200
     # TODO flesh this out


### PR DESCRIPTION
Moved reads/writes of keys.json into the endpoint methods to make it more like database reads/writes. Updated unit tests with a cleanup fixture that runs before and after each test so that tests don't depend on each other.